### PR TITLE
メッセージ投稿機能の追加

### DIFF
--- a/app/Http/Livewire/CreateMessageForm.php
+++ b/app/Http/Livewire/CreateMessageForm.php
@@ -27,9 +27,13 @@ class CreateMessageForm extends Component
     public function onSubmit()
     {
         $this->content = trim($this->content);
-        if ($this->content && strlen($this->content) <= self::MaxLength) {
-            Message::create(['user_id' => Auth::user()->id, 'content' => $this->content]);
-            redirect(request()->header('Referer')); // reload page
+        if ($this->content) {
+            if (strlen($this->content) <= self::MaxLength) {
+                Message::create(['user_id' => Auth::user()->id, 'content' => $this->content]);
+                redirect(request()->header('Referer')); // reload page
+            } else {
+                $this->addError('content', '255文字以下のメッセージしか送信できません');
+            }
         }
     }
 }

--- a/app/Http/Livewire/CreateMessageForm.php
+++ b/app/Http/Livewire/CreateMessageForm.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Livewire;
+
+use App\Models\Message;
+use Auth;
+use Livewire\Component;
+
+class CreateMessageForm extends Component
+{
+    public $content = '';
+
+    public function render()
+    {
+        return view('livewire.create-message-form');
+    }
+
+    public function onSubmit()
+    {
+        $this->content = trim($this->content);
+        if ($this->content) {
+            Message::create(['user_id' => Auth::user()->id, 'content' => $this->content]);
+            redirect(request()->header('Referer')); // reload page
+        }
+    }
+}

--- a/app/Http/Livewire/CreateMessageForm.php
+++ b/app/Http/Livewire/CreateMessageForm.php
@@ -28,7 +28,7 @@ class CreateMessageForm extends Component
     {
         $this->content = trim($this->content);
         if ($this->content) {
-            if (strlen($this->content) <= self::MaxLength) {
+            if (mb_strlen($this->content) <= self::MaxLength) {
                 Message::create(['user_id' => Auth::user()->id, 'content' => $this->content]);
                 redirect(request()->header('Referer')); // reload page
             } else {

--- a/app/Http/Livewire/CreateMessageForm.php
+++ b/app/Http/Livewire/CreateMessageForm.php
@@ -8,6 +8,13 @@ use Livewire\Component;
 
 class CreateMessageForm extends Component
 {
+    /**
+     * メッセージの最大長
+     *
+     * - [処理の流れ] フロントエンドから送信されたメッセージの先頭・末尾の空白を削除(trim)してデータベースに格納する
+     * - [フロントエンド] 処理の簡略化のために先頭・末尾の空白を考慮して文字列の長さを求める
+     * - [バックエンド] 先頭・末尾の空白を削除してから文字列の長さを求める
+     */
     const MaxLength = 255;
 
     public $content = '';

--- a/app/Http/Livewire/CreateMessageForm.php
+++ b/app/Http/Livewire/CreateMessageForm.php
@@ -8,6 +8,8 @@ use Livewire\Component;
 
 class CreateMessageForm extends Component
 {
+    const MaxLength = 255;
+
     public $content = '';
 
     public function render()
@@ -18,7 +20,7 @@ class CreateMessageForm extends Component
     public function onSubmit()
     {
         $this->content = trim($this->content);
-        if ($this->content) {
+        if ($this->content && strlen($this->content) <= self::MaxLength) {
             Message::create(['user_id' => Auth::user()->id, 'content' => $this->content]);
             redirect(request()->header('Referer')); // reload page
         }

--- a/resources/views/livewire/create-message-form.blade.php
+++ b/resources/views/livewire/create-message-form.blade.php
@@ -1,6 +1,11 @@
-<div class="border border-gray-800">
-    <textarea class="block resize-none border-none w-full p-2" rows="4" maxlength="{{ \App\Http\Livewire\CreateMessageForm::MaxLength }}" wire:model.defer="content" type="text"></textarea>
-    <button class="border-t border-gray-800 bg-green-300 w-full" wire:click="onSubmit">
-        <p class="text-lg text-center m-1">Submit</p>
-    </button>
+<div>
+    @error('content')
+        <span class="text-red-600 text-sm error">{{ $message }}</span>
+    @enderror
+    <div class="border border-gray-800">
+        <textarea class="block resize-none border-none w-full p-2" rows="4" maxlength="{{ \App\Http\Livewire\CreateMessageForm::MaxLength }}" wire:model.defer="content" type="text"></textarea>
+        <button class="border-t border-gray-800 bg-green-300 w-full" wire:click="onSubmit">
+            <p class="text-lg text-center m-1">Submit</p>
+        </button>
+    </div>
 </div>

--- a/resources/views/livewire/create-message-form.blade.php
+++ b/resources/views/livewire/create-message-form.blade.php
@@ -1,5 +1,5 @@
 <div class="border border-gray-800">
-    <textarea class="block resize-none border-none w-full p-2" rows="4" wire:model.defer="content" type="text"></textarea>
+    <textarea class="block resize-none border-none w-full p-2" rows="4" maxlength="{{ \App\Http\Livewire\CreateMessageForm::MaxLength }}" wire:model.defer="content" type="text"></textarea>
     <button class="border-t border-gray-800 bg-green-300 w-full" wire:click="onSubmit">
         <p class="text-lg text-center m-1">Submit</p>
     </button>

--- a/resources/views/livewire/create-message-form.blade.php
+++ b/resources/views/livewire/create-message-form.blade.php
@@ -1,0 +1,6 @@
+<div class="border border-gray-800">
+    <textarea class="block resize-none border-none w-full p-2" rows="4" wire:model.defer="content" type="text"></textarea>
+    <button class="border-t border-gray-800 bg-green-300 w-full" wire:click="onSubmit">
+        <p class="text-lg text-center m-1">Submit</p>
+    </button>
+</div>

--- a/resources/views/timeline.blade.php
+++ b/resources/views/timeline.blade.php
@@ -6,6 +6,9 @@
     </x-slot>
 
     <div class="md:container md:mx-auto shadow-lg py-2">
+        <div class="m-2">
+            <livewire:create-message-form />
+        </div>
         @foreach($messages as $message)
             <div class="border-b border-gray-400 m-2">
                 <div class="flex justify-between text-lg border-b">

--- a/tests/Feature/MessageTest.php
+++ b/tests/Feature/MessageTest.php
@@ -73,10 +73,85 @@ class MessageTest extends TestCase
         $this->assertNull($message);
     }
 
-    public function test_too_long_message_is_not_created() {
+    public function test_max_length_alpha_message_can_be_created() {
         $user = User::factory()->create();
         $this->actingAs($user);
-        $content = Str::random(CreateMessageForm::MaxLength + 1);
+        $content = str_repeat('a', CreateMessageForm::MaxLength);
+
+        $livewire = Livewire::test(CreateMessageForm::class, ['content' => $content]);
+        $livewire->call('onSubmit');
+
+        $message = Message::all()
+            ->where('user_id', $user->id)
+            ->where('content', $content)
+            ->first();
+        $this->assertNotNull($message);
+    }
+
+    public function test_too_long_alpha_message_is_not_created() {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        $content = str_repeat('a', CreateMessageForm::MaxLength + 1);
+
+        $livewire = Livewire::test(CreateMessageForm::class, ['content' => $content]);
+        $livewire->call('onSubmit');
+
+        $message = Message::all()
+            ->where('user_id', $user->id)
+            ->where('content', $content)
+            ->first();
+        $this->assertNull($message);
+    }
+
+    public function test_max_length_utf8_message_can_be_created() {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        $content = str_repeat('あ', CreateMessageForm::MaxLength);
+
+        $livewire = Livewire::test(CreateMessageForm::class, ['content' => $content]);
+        $livewire->call('onSubmit');
+
+        $message = Message::all()
+            ->where('user_id', $user->id)
+            ->where('content', $content)
+            ->first();
+        $this->assertNotNull($message);
+    }
+
+    public function test_too_long_utf8_message_is_not_created() {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        $content = str_repeat('あ', CreateMessageForm::MaxLength + 1);
+
+        $livewire = Livewire::test(CreateMessageForm::class, ['content' => $content]);
+        $livewire->call('onSubmit');
+
+        $message = Message::all()
+            ->where('user_id', $user->id)
+            ->where('content', $content)
+            ->first();
+        $this->assertNull($message);
+    }
+
+    public function test_max_length_utf8mb4_message_can_be_created() {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        $content = str_repeat('😀', CreateMessageForm::MaxLength);
+
+        $livewire = Livewire::test(CreateMessageForm::class, ['content' => $content]);
+        $livewire->call('onSubmit');
+
+        $message = Message::all()
+            ->where('user_id', $user->id)
+            ->where('content', $content)
+            ->first();
+        $this->assertNotNull($message);
+    }
+
+    public function test_too_long_utf8mb4_message_is_not_created() {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        $content = str_repeat('😀', CreateMessageForm::MaxLength + 1);
 
         $livewire = Livewire::test(CreateMessageForm::class, ['content' => $content]);
         $livewire->call('onSubmit');

--- a/tests/Feature/MessageTest.php
+++ b/tests/Feature/MessageTest.php
@@ -73,6 +73,21 @@ class MessageTest extends TestCase
         $this->assertNull($message);
     }
 
+    public function test_too_long_message_is_not_created() {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        $content = Str::random(CreateMessageForm::MaxLength + 1);
+
+        $livewire = Livewire::test(CreateMessageForm::class, ['content' => $content]);
+        $livewire->call('onSubmit');
+
+        $message = Message::all()
+            ->where('user_id', $user->id)
+            ->where('content', $content)
+            ->first();
+        $this->assertNull($message);
+    }
+
     public function test_message_screen_can_be_rendered()
     {
         $user = User::factory()->create();

--- a/tests/Feature/MessageTest.php
+++ b/tests/Feature/MessageTest.php
@@ -2,10 +2,12 @@
 
 namespace Tests\Feature;
 
+use App\Http\Livewire\CreateMessageForm;
 use App\Http\Livewire\LikeButton;
 use App\Models\Message;
 use App\Models\User;
 use Livewire\Livewire;
+use Str;
 use Tests\TestCase;
 
 class MessageTest extends TestCase
@@ -18,11 +20,57 @@ class MessageTest extends TestCase
         $response = $this->actingAs($user)->get(route('timeline'));
 
         $response->assertOk();
+        $response->assertSeeLivewire(CreateMessageForm::class);
         foreach ($messages as $message) {
             $response->assertSee($message->user->name);
             $response->assertSee($message->content);
             $response->assertSeeLivewire(LikeButton::class);
         }
+    }
+
+    public function test_message_can_be_created() {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        $content = Str::random();
+
+        $livewire = Livewire::test(CreateMessageForm::class, ['content' => $content]);
+        $livewire->call('onSubmit');
+
+        $message = Message::all()
+            ->where('user_id', $user->id)
+            ->where('content', $content)
+            ->first();
+        $this->assertNotNull($message);
+    }
+
+    public function test_message_is_trimmed() {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        $content = ' ' . Str::random() . ' ';
+
+        $livewire = Livewire::test(CreateMessageForm::class, ['content' => $content]);
+        $livewire->call('onSubmit');
+
+        $message = Message::all()
+            ->where('user_id', $user->id)
+            ->where('content', trim($content))
+            ->first();
+        $this->assertNotNull($message);
+    }
+
+    public function test_blank_message_is_not_created() {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+        $content = ' ';
+
+        $livewire = Livewire::test(CreateMessageForm::class, ['content' => $content]);
+        $livewire->call('onSubmit');
+
+        $message = Message::all()
+            ->where('user_id', $user->id)
+            ->where('content', $content)
+            ->first();
+        $this->assertNull($message);
     }
 
     public function test_message_screen_can_be_rendered()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/34268371/133368839-fe39c560-3ea3-4856-92a6-edd0910cb9a9.png)

- メッセージを入力して `Submit` を押すと送信できる
- 送信後にページがリロードされ、タイムラインが自動更新される
- 先頭・末尾にある空白は削除される
- 空白のメッセージを送信しようとしてもボタンが反応しない
- 255文字までしか入力できない